### PR TITLE
Openwrt 21.02 pr更新 2021.7.19

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-1200.dts
@@ -68,7 +68,7 @@
 
 		edma@c080000 {
 			status = "okay";
-			phy-mode = "rgmii-rxid";
+			phy-mode = "rgmii-id";
 			qcom,num_gmac = <1>;
 			qcom,single-phy;
 		};


### PR DESCRIPTION
When the AVM FRITZ!Repeater 1200 was introduced on Kernel 4.19, the
at803x PHY driver incorrectly set up the delays, not disabling delays
set by the bootloader.

The PHY was always operating with RX as well as TX delays enabled, but
with kernel 5.4 and later, the required TX delay is disabled, breaking
ethernet operation.

Correct the PHY mode, so the driver enables both delays.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit f9d18281051c894eacd40f10c10b430c6c9082ad)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
